### PR TITLE
NC relays startup in "ON" state so output handler needs to know this on initialisation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,7 +634,8 @@ void scanI2CBus()
       if (mcp == MCP_OUTPUT_INDEX)
       {
         // Initialise the output handler (default to RELAY, not configurable)
-        oxrsOutput.begin(outputEvent, RELAY);
+        // NOTE: the PDU relays are NC - so startup in ON state
+        oxrsOutput.begin(outputEvent, RELAY, RELAY_ON);
       }
       if (mcp == MCP_INPUT_INDEX)
       {


### PR DESCRIPTION
Depends on https://github.com/OXRS-IO/OXRS-IO-IOHandler-ESP32-LIB/pull/2 (IO-Handler v1.5.0)